### PR TITLE
fix: 立替登録時のユーザー選択機能を削除

### DIFF
--- a/lambda/webhook/features/cost/lineTemplates.ts
+++ b/lambda/webhook/features/cost/lineTemplates.ts
@@ -1,5 +1,4 @@
 import type {
-  TemplateButtons,
   TemplateCarousel,
   TemplateConfirm,
   QuickReply,
@@ -10,33 +9,9 @@ import {
   CATEGORY_NAMES,
   CATEGORY_IMAGES,
   CATEGORY_DESCRIPTIONS,
-  BOT_MESSAGES,
   POSTBACK_DATA,
   MEMO_QUICK_REPLIES_BY_CATEGORY,
 } from "../../../shared/constants";
-import type { AcceptedUser } from "./userCache";
-
-/**
- * Creates initial user selection button template with dynamic users
- */
-export const createUserSelectionTemplate = (
-  users: AcceptedUser[],
-): TemplateButtons => ({
-  type: "buttons",
-  text: BOT_MESSAGES.START,
-  actions: [
-    ...users.map((user) => ({
-      type: "postback" as const,
-      label: user.displayName,
-      data: `payment_user=${user.lineUserId}`,
-    })),
-    {
-      type: "postback",
-      label: "キャンセル",
-      data: POSTBACK_DATA.CANCEL,
-    },
-  ],
-});
 
 /**
  * Creates category selection carousel template

--- a/lambda/webhook/features/cost/textEventHandler.ts
+++ b/lambda/webhook/features/cost/textEventHandler.ts
@@ -4,7 +4,7 @@ import type { PaymentCategory } from "../../../shared/types";
 import { BOT_MESSAGES } from "../../../shared/constants";
 import { userService } from "../../../backend/features/user/userService";
 import {
-  createUserSelectionTemplate,
+  createCategoryCarouselTemplate,
   createConfirmationTemplate,
 } from "./lineTemplates";
 import { getAcceptedUsers } from "./userCache";
@@ -25,26 +25,19 @@ export const textEventHandler = async (
   let response: line.Message;
 
   if (text === "入力を始める") {
-    // Reset user state and start fresh
-    await userService.saveUserState(userId, { step: "idle" });
+    // Set state to user_selected with the current user and show category selection
+    await userService.saveUserState(userId, {
+      step: "user_selected",
+      user: userId,
+    });
 
-    // Fetch accepted users
-    const users = await getAcceptedUsers();
+    const carouselTemplate = createCategoryCarouselTemplate(userId);
 
-    if (users.length === 0) {
-      response = {
-        type: "text",
-        text: "❌ 登録済みユーザーが見つかりません。管理者に連絡してください。",
-      };
-    } else {
-      const buttonTemplate = createUserSelectionTemplate(users);
-
-      response = {
-        type: "template",
-        altText: BOT_MESSAGES.START,
-        template: buttonTemplate,
-      };
-    }
+    response = {
+      type: "template",
+      altText: "支払いカテゴリを選択してください",
+      template: carouselTemplate,
+    };
   } else if (text === "やめる" || text === "キャンセル" || text === "終了") {
     // Cancel current session and clear state
     await userService.deleteUserState(userId);


### PR DESCRIPTION
ログインユーザー以外を選択するとPOSTエラーが発生する不具合の根本対応として、
ユーザー選択ステップを廃止し、操作しているユーザー自身を自動的に使用するよう変更。

- textEventHandler: 「入力を始める」で直接カテゴリ選択へ遷移
- postbackEventHandler: payment_user= ハンドラを削除
- lineTemplates: createUserSelectionTemplate を削除

https://claude.ai/code/session_015UExoTuiQgGJ4EetpmaGkH