### PR TITLE
feat: allow adding cost entries for past months

### DIFF
--- a/frontend/src/components/AddDetailDialog.tsx
+++ b/frontend/src/components/AddDetailDialog.tsx
@@ -42,7 +42,31 @@ import { listUsers } from "@/server/listUsers";
 
 type FormValues = z.infer<typeof CreateCostDataSchema>;
 
-function SubmitForm({ onSuccess }: { onSuccess?: () => void }) {
+function formatDateInput(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(
+    date.getDate(),
+  ).padStart(2, "0")}`;
+}
+
+function getDefaultDateForMonth(year: number, month: number): string {
+  const today = new Date();
+  const isCurrentMonth =
+    year === today.getFullYear() && month === today.getMonth() + 1;
+  if (isCurrentMonth) {
+    return formatDateInput(today);
+  }
+  return `${year}-${String(month).padStart(2, "0")}-01`;
+}
+
+function SubmitForm({
+  onSuccess,
+  year,
+  month,
+}: {
+  onSuccess?: () => void;
+  year: number;
+  month: number;
+}) {
   const auth = useAuth();
   const username = (auth.user?.profile.username as string)?.split("_")[1] ?? "";
   const lineUserId = username.charAt(0).toUpperCase() + username.slice(1);
@@ -57,6 +81,9 @@ function SubmitForm({ onSuccess }: { onSuccess?: () => void }) {
       costType: "split",
     },
   });
+  const [dateValue, setDateValue] = useState(() =>
+    getDefaultDateForMonth(year, month),
+  );
 
   const createCostDetail = useCreateCost();
 
@@ -75,10 +102,12 @@ function SubmitForm({ onSuccess }: { onSuccess?: () => void }) {
 
   const onSubmit: SubmitHandler<FormValues> = async (data) => {
     try {
-      const result = await createCostDetail(data);
+      const timestamp = new Date(`${dateValue}T12:00:00Z`).getTime();
+      const result = await createCostDetail({ ...data, timestamp });
       toast("新しい項目が追加されました", {});
       console.log(result);
       form.reset();
+      setDateValue(getDefaultDateForMonth(year, month));
       onSuccess?.();
       return result;
     } catch (error) {
@@ -90,6 +119,20 @@ function SubmitForm({ onSuccess }: { onSuccess?: () => void }) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="w-full space-y-6">
+        <FormItem>
+          <FormLabel htmlFor="cost-date">日付</FormLabel>
+          <FormControl>
+            <Input
+              id="cost-date"
+              type="date"
+              value={dateValue}
+              onChange={(e) => setDateValue(e.target.value)}
+            />
+          </FormControl>
+          <FormDescription>
+            過去の月の項目もこの日付を変更することで登録できます
+          </FormDescription>
+        </FormItem>
         <FormField
           control={form.control}
           name="category"
@@ -173,7 +216,13 @@ function SubmitForm({ onSuccess }: { onSuccess?: () => void }) {
   );
 }
 
-export function AddDetailDialog() {
+export function AddDetailDialog({
+  year,
+  month,
+}: {
+  year: number;
+  month: number;
+}) {
   const [open, setOpen] = useState(false);
 
   const handleSuccess = useCallback(() => {
@@ -197,7 +246,7 @@ export function AddDetailDialog() {
           </DialogDescription>
         </DialogHeader>
         <div>
-          <SubmitForm onSuccess={handleSuccess} />
+          <SubmitForm onSuccess={handleSuccess} year={year} month={month} />
         </div>
         <DialogFooter className="sm:justify-start">
           <DialogClose asChild>

--- a/frontend/src/components/MonthlyCostTable.tsx
+++ b/frontend/src/components/MonthlyCostTable.tsx
@@ -110,7 +110,7 @@ export function MonthlyCostTable({
         onCompleteSettlement={handleCompleteSettlement}
       />
       <div className="flex justify-end mb-4">
-        <AddDetailDialog />
+        <AddDetailDialog year={year} month={month} />
       </div>
       <UserSummaryTable
         year={year}

--- a/lambda/backend/features/cost/costService.ts
+++ b/lambda/backend/features/cost/costService.ts
@@ -34,7 +34,7 @@ export class CostService {
     try {
       this.validateCreateCostData(data);
 
-      const timestamp = Date.now();
+      const timestamp = data.timestamp ?? Date.now();
       const now = new Date().toISOString();
       const date = new Date(timestamp);
       const yearMonth = `${date.getFullYear()}-${String(
@@ -279,6 +279,10 @@ export class CostService {
 
     if (!data.userId || data.userId.trim() === "") {
       throw new Error("User ID is required");
+    }
+
+    if (data.timestamp !== undefined && data.timestamp > Date.now()) {
+      throw new Error("Timestamp cannot be in the future");
     }
   }
 

--- a/lambda/backend/features/cost/schemas.ts
+++ b/lambda/backend/features/cost/schemas.ts
@@ -14,6 +14,7 @@ export const CreateCostDetailSchema = z.object({
   memo: z.string(),
   price: z.number(),
   costType: z.enum(["split", "charge"]).default("split"),
+  timestamp: z.number().optional(),
 });
 
 export const UpdateCostDetailSchema = z

--- a/lambda/shared/types.ts
+++ b/lambda/shared/types.ts
@@ -101,6 +101,7 @@ export const CreateCostDataSchema = z.object({
   memo: z.string(),
   price: z.number().gt(0),
   costType: CostTypeSchema.default("split"),
+  timestamp: z.number().optional(), // Epoch ms; defaults to now when omitted, allows recording past months
 });
 export type CreateCostData = z.infer<typeof CreateCostDataSchema>;
 


### PR DESCRIPTION
The "新規追加" dialog always saved new entries under the current
real-world date, even when opened from a past month's tab, so
past-month spending could never be recorded through the UI. Add a
date field to the form (defaulting to the viewed month) and thread an
optional timestamp through the create API so the entry is recorded
under the selected date instead of Date.now().

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ABgV9FekC7s1LTSsLYi2r8