### PR TITLE
fix: prevent DB errors from masking as "system not initialized"

### DIFF
--- a/lambda/backend/features/invitation/invitationService.ts
+++ b/lambda/backend/features/invitation/invitationService.ts
@@ -44,7 +44,10 @@ export class InvitationService {
       return acceptedResult.length > 0;
     } catch (error) {
       logger.error("Error checking system initialization", { error });
-      return false; // Fail safe
+      // Do not mask query failures as "not initialized" - that would
+      // incorrectly show the first-time setup screen to existing users
+      // and could allow re-bootstrapping an already-initialized system.
+      throw error;
     }
   }
 

--- a/lambda/cognito/postAuthentication.ts
+++ b/lambda/cognito/postAuthentication.ts
@@ -36,8 +36,24 @@ export const handler: PostAuthenticationTriggerHandler = async (event) => {
   console.log("PostAuthentication event:", JSON.stringify(event, null, 2));
 
   const identities = event.request.userAttributes?.identities;
-  const parsedIds = JSON.parse(identities);
-  const userId = parsedIds[0].userId;
+
+  if (!identities) {
+    console.error("Authentication failed: No federated identities found on user");
+    throw new Error("Unauthorized user - No federated identity found");
+  }
+
+  let userId: string | undefined;
+  try {
+    const parsedIds = JSON.parse(identities);
+    userId = parsedIds?.[0]?.userId;
+  } catch (error) {
+    console.error("Authentication failed: Could not parse identities", {
+      error,
+      identities,
+    });
+    throw new Error("Unauthorized user - Invalid identity data");
+  }
+
   console.log("Extracted LINE user ID from identities:", userId);
 
   if (!userId) {


### PR DESCRIPTION
isSystemInitialized() was catching all errors and returning false,
which made a transient DynamoDB query failure indistinguishable from
a genuinely empty system - showing the first-time setup screen to
existing users instead of the login screen. It now rethrows so the
error surfaces as a failed request, and the frontend's existing
fallback (default to showing the login screen on fetch failure)
takes over instead.

Also hardens the postAuthentication Cognito trigger against a missing
or malformed `identities` attribute, which previously crashed with an
unhandled JSON.parse error instead of failing with a clear message.